### PR TITLE
Keep window position and size between runs

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const Shortcut = require('electron-shortcut');
 const togglify = require('electron-togglify-window');
+const windowStateKeeper = require('electron-window-state');
 const Configstore = require('configstore');
 
 const pkg = require(path.join(__dirname, './package.json'));
@@ -29,9 +30,16 @@ app.on('window-all-closed', () => {
 });
 
 app.on('ready', () => {
+	let mainWindowState = windowStateKeeper({
+		defaultWidth: 800,
+		defaultHeight: 600
+	});
+
 	win = togglify(new BrowserWindow({
-		width: 800,
-		height: 600,
+		x: mainWindowState.x,
+		y: mainWindowState.y,
+		width: mainWindowState.width,
+		height: mainWindowState.height,
 		resizable: true,
 		center: true,
 		show: true,
@@ -42,6 +50,8 @@ app.on('ready', () => {
 	}), {
 		animation: conf.get('animation')
 	});
+
+	mainWindowState.manage(win);
 
 	win.loadURL('http://devdocs.io');
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "electron-debug": "^0.5.1",
     "electron-menu-loader": "0.0.3",
     "electron-shortcut": "^0.4.1",
-    "electron-togglify-window": "^0.1.0"
+    "electron-togglify-window": "^0.1.0",
+    "electron-window-state": "^2.0.0"
   },
   "xo": {
     "esnext": true,


### PR DESCRIPTION
Hey! I have added [electron-window-state](https://github.com/mawie81/electron-window-state) plugin that saves/loads window state. Now app remembers window's position+size on close and will restore these values after a restart.
