### PR TITLE
Fixed app version for packaging in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
   "config": {
     "ignore": "--ignore='^/res$' --ignore='^/dist$' --ignore='^/node_modules$'",
     "platform": "--platform=darwin --arch=x64 --prune --asar --icon=res/icon-128.icns",
-    "version": "--version=0.36.3 --app-bundle-id=me.ragingwind.devdocs --app-version=$npm_package_version"
+    "version": "--version=0.36.3 --app-bundle-id=me.ragingwind.devdocs"
   },
   "scripts": {
     "start": "electron ./",
     "test": "xo",
     "clean": "rm -rf build package",
-    "build": "electron-packager . $npm_package_productName --out=./dist --overwrite $npm_package_config_platform $npm_package_config_version $npm_package_config_ignore",
+    "build": "electron-packager . $npm_package_productName --out=./dist --overwrite --app-version=$npm_package_version $npm_package_config_platform $npm_package_config_version $npm_package_config_ignore",
     "package": "cd dist/${npm_package_productName}-darwin-x64 && zip -ryXq9 ../${npm_package_productName}-${npm_package_version}.zip ${npm_package_productName}.app"
   },
   "files": [


### PR DESCRIPTION
Using $npm_package_version in a config string can't resolve the version stated above and ended building the app without correct version.

``` xml
<key>CFBundleShortVersionString</key>
<string>$npm_package_version</string>
<key>CFBundleVersion</key>
<string>$npm_package_version</string>
```

By moving it directly in the script it can be resolved and the app will have the correct version

``` xml
<key>CFBundleShortVersionString</key>
<string>0.1.11</string>
<key>CFBundleVersion</key>
<string>0.1.11</string>
```
