### PR TITLE
fixes resolving 'menu' in package app require

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV !== 'production') {
 	require('electron-debug')();
 }
 
-require('electron-menu-loader')('./menu');
+require('electron-menu-loader')(require('./menu'));
 
 // prevent window being GC'd
 let win = null;


### PR DESCRIPTION
The app was building correctly under macOS Sierra, but threw on launch that the module resolver could not find the `menu`. Upon closer inspection, it was the `menu.js` file. Explicitly requiring it solves the issue.